### PR TITLE
Fix bug where customCriteria was always required

### DIFF
--- a/src/addtohomescreen.js
+++ b/src/addtohomescreen.js
@@ -664,8 +664,7 @@
 
 			this._canPrompt = false;
 
-			if ( _instance.options.customCriteria !== null ||
-				_instance.options.customCriteria !== undefined ) {
+			if ( _instance.options.customCriteria) {
 
 				var passCustom = false;
 


### PR DESCRIPTION
The old logic: _instance.options.customCriteria !== null || _instance.options.customCriteria !== undefined
will *ALWAYS* return true.